### PR TITLE
Update RenderArticle.tsx

### DIFF
--- a/app/components/dashboard/RenderArticle.tsx
+++ b/app/components/dashboard/RenderArticle.tsx
@@ -14,6 +14,8 @@ import BlockQuote from "@tiptap/extension-blockquote";
 import TextStyle from "@tiptap/extension-text-style";
 import CodeBlock from "@tiptap/extension-code-block";
 import OrderList from "@tiptap/extension-ordered-list";
+import Bold from "@tiptap/extension-bold"; // Ajoutez cette ligne
+import HardBreak from "@tiptap/extension-hard-break"; // Ajoutez cette ligne
 
 export function RenderArticle({ json }: { json: JSONContent }) {
   const outPut = useMemo(() => {
@@ -31,6 +33,8 @@ export function RenderArticle({ json }: { json: JSONContent }) {
       TextStyle,
       CodeBlock,
       OrderList,
+      Bold, // Ajoutez cette ligne
+      HardBreak, // Ajoutez cette ligne
     ]);
   }, [json]);
 


### PR DESCRIPTION
 "J'ai remarqué que le composant ne prenait pas en charge le type de nœud hardBreak et Bold, ce qui provoquait des erreurs lors du rendu du contenu JSON contenant des sauts de ligne."

 "Cette modification améliore la robustesse du composant en évitant les erreurs liées à des types de nœuds inconnus et permet de rendre du texte avec des sauts de ligne de manière fiable."